### PR TITLE
Added the function `generate_id` to create a unique UUID. 

### DIFF
--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -2,8 +2,9 @@ person_mapping:
   source_table: patients
   target_table: person
   transformations:
-    - source_column: subject_id
-      target_column: person_id
+    - target_column: person_id
+      transformation:
+        type: generate_id
     - source_column: gender
       target_column: gender_concept_id
       transformation:

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -1,5 +1,5 @@
 import os
-
+import uuid
 import pandas as pd
 
 
@@ -194,6 +194,10 @@ class Transformer:
             if f"{part}_of_birth" in transformation["target_columns"]:
                 self.data[f"{part}_of_birth"] = pd.to_datetime(self.data[source_column]).dt.__getattribute__(part)
         return self.data
+    
+    def transform_generate_id(self, source_column, target_column, transformation):
+        """Generate a universal unique identifier for each row in the source column."""
+        return [str(uuid.uuid4()) for _ in range(len(self.data))]
 
     # Helper method
     def perform_lookup(self, vocabulary, code):

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -169,3 +169,17 @@ def test_derive(transformer, project_path):
     ]
     transformed_data = transformer.apply_transformations(transformations, project_path)
     assert "derived_column" in transformed_data.columns
+
+
+def test_generate_id(transformer, project_path):
+    transformations = [
+        {
+            "target_column": "person_id",
+            "transformation": {
+                "type": "generate_id"
+            },
+        }
+    ]
+    transformed_data = transformer.apply_transformations(transformations, project_path)
+    assert transformed_data is not None
+    assert len(transformed_data) == 3


### PR DESCRIPTION
This pull request:
    - Implements function to generate a universal unique identifier (UUID) for each row.
    - Modifies the target column in the DataFrame with generated UUIDs.
    - Ensures that UUIDs are correctly applied for each row based on the source column.
    - Add a test for the `generate_id` function.