### PR TITLE
Update demo config files to match MIMIC-IV demo data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,11 @@ jobs:
 
     - name: Run template tests
       run: pytest tests
+
+    - name: Test omopetl CLI commands
+      run: |
+        # Create a demo project
+        omopetl startdemo DEMO
+
+        # Run the ETL in dry mode
+        omopetl run DEMO --dry

--- a/omopetl/cli.py
+++ b/omopetl/cli.py
@@ -1,6 +1,9 @@
 import os
 import shutil
 import click
+import yaml
+
+import pandas as pd
 
 from omopetl.pipeline import run_etl
 
@@ -39,6 +42,84 @@ def startdemo(project_name):
 
     shutil.copytree(DEMO_TEMPLATE_DIR, project_path)
     print(f"Demo project '{project_name}' created successfully at {project_path}")
+
+
+@cli.command()
+@click.argument("csv_directory", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path(writable=True), default="source_schema.yaml")
+def inferschema(csv_directory, output_file):
+    """
+    Infer a source_schema.yaml file from CSV files in a directory.
+
+    Parameters:
+    - csv_directory: Directory containing the CSV files.
+    - output_file: Output YAML file to save the schema.
+    """
+    schema = {}
+
+    for file_name in os.listdir(csv_directory):
+        if file_name.endswith(".csv"):
+            table_name = os.path.splitext(file_name)[0]
+            file_path = os.path.join(csv_directory, file_name)
+            df = pd.read_csv(file_path)
+
+            # Infer schema
+            columns = {}
+            potential_primary_keys = []
+
+            for col_name, dtype in df.dtypes.items():
+                # Map Pandas dtypes to schema types
+                if pd.api.types.is_integer_dtype(dtype):
+                    col_type = "Integer"
+                elif pd.api.types.is_float_dtype(dtype):
+                    col_type = "Float"
+                elif pd.api.types.is_datetime64_any_dtype(dtype):
+                    col_type = "DateTime"
+                elif pd.api.types.is_bool_dtype(dtype):
+                    col_type = "Boolean"
+                else:
+                    col_type = "String"
+
+                # Add column to schema
+                columns[col_name] = {"type": col_type}
+
+                # Check uniqueness and non-null for potential primary key
+                if df[col_name].is_unique and df[col_name].notnull().all():
+                    potential_primary_keys.append(col_name)
+
+            # Apply heuristics to select the primary key
+            primary_key = None
+            for key_candidate in potential_primary_keys:
+                if key_candidate == "id" or key_candidate == f"{table_name}_id" or key_candidate.endswith("_id"):
+                    primary_key = key_candidate
+                    break
+            if not primary_key and potential_primary_keys:
+                # Default to the first unique column
+                primary_key = potential_primary_keys[0]
+
+            if primary_key:
+                columns[primary_key]["primary_key"] = True
+
+            schema[table_name] = {"table_name": table_name, "columns": columns}
+
+    # Sort schema file alphabetically
+    sorted_schema = dict(sorted(schema.items()))
+
+    # Write schema to YAML with a header comment and empty lines between tables
+    with open(output_file, "w") as yaml_file:
+        # Add header
+        yaml_file.write(
+            "# This schema was automatically inferred by omopetl.\n"
+            "# Please review and adjust it carefully before using.\n\n"
+        )
+
+        # Write schema with empty lines between tables
+        yaml_file.write("\n".join(
+            yaml.dump({table: sorted_schema[table]}, default_flow_style=False, sort_keys=False)
+            for table in sorted_schema
+        ))
+
+    click.echo(f"Inferred schema saved to {output_file}. Please review it carefully.")
 
 
 @cli.command()

--- a/omopetl/models.py
+++ b/omopetl/models.py
@@ -16,6 +16,7 @@ def create_model(table_name, schema):
         attributes[column_name] = Column(column_type, primary_key=column_properties.get('primary_key', False))
     return type(table_name.capitalize(), (Base,), attributes)
 
+
 def load_models(schema_file):
     with open(schema_file, 'r') as f:
         schema = yaml.safe_load(f)

--- a/omopetl/pipeline.py
+++ b/omopetl/pipeline.py
@@ -79,7 +79,7 @@ def validate_schema(data, schema, table_name):
 
     extra_columns = [col for col in actual_columns if col not in expected_columns]
     if extra_columns:
-        print(f"Warning: Extra columns in {table_name}: {extra_columns}")
+        print(f"Warning: Columns present in {table_name} table, but not schema file: {extra_columns}")
 
 
 def validate_data(data, validation_rules, table_name):

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -8,8 +8,6 @@ person_mapping:
       values:
         M: 8507
         F: 8532
-  - source_column: dob
-    target_column: birth_datetime
 
 visit_occurrence_mapping:
   - source_column: hadm_id

--- a/omopetl/templates/demo/config/source_schema.yaml
+++ b/omopetl/templates/demo/config/source_schema.yaml
@@ -1,59 +1,79 @@
-patients:
-  table_name: patients
-  columns:
-    subject_id:
-      type: Integer
-      primary_key: true
-    gender:
-      type: String
-    dob:
-      type: DateTime
-    dod:
-      type: DateTime
+# This schema was automatically inferred by omopetl.
+# Please review and adjust it carefully before using.
 
 admissions:
   table_name: admissions
   columns:
+    subject_id:
+      type: Integer
     hadm_id:
       type: Integer
       primary_key: true
-    subject_id:
-      type: Integer
     admittime:
-      type: DateTime
+      type: String
     dischtime:
-      type: DateTime
+      type: String
+    deathtime:
+      type: String
     admission_type:
       type: String
-
-transfers:
-  table_name: transfers
-  columns:
-    transfer_id:
-      type: Integer
-    hadm_id:
-      type: Integer
-    transfer_time:
-      type: DateTime
-    leave_time:
-      type: DateTime
-    service:
+    admit_provider_id:
       type: String
-
-icustays:
-  table_name: icustays
-  columns:
-    stay_id:
+    admission_location:
+      type: String
+    discharge_location:
+      type: String
+    insurance:
+      type: String
+    language:
+      type: String
+    marital_status:
+      type: String
+    race:
+      type: String
+    edregtime:
+      type: String
+    edouttime:
+      type: String
+    hospital_expire_flag:
       type: Integer
-      primary_key: true
+
+chartevents:
+  table_name: chartevents
+  columns:
     subject_id:
       type: Integer
     hadm_id:
       type: Integer
-    intime:
-      type: DateTime
-    outtime:
-      type: DateTime
+    stay_id:
+      type: Integer
+    caregiver_id:
+      type: Float
+    charttime:
+      type: String
+    storetime:
+      type: String
+    itemid:
+      type: Integer
+    value:
+      type: String
+    valuenum:
+      type: Float
+    valueuom:
+      type: String
+    warning:
+      type: Float
+
+d_icd_diagnoses:
+  table_name: d_icd_diagnoses
+  columns:
+    icd_code:
+      type: Integer
+      primary_key: true
+    icd_version:
+      type: Integer
+    long_title:
+      type: String
 
 diagnoses_icd:
   table_name: diagnoses_icd
@@ -62,11 +82,191 @@ diagnoses_icd:
       type: Integer
     hadm_id:
       type: Integer
+    seq_num:
+      type: Integer
+      primary_key: true
     icd_code:
       type: String
     icd_version:
       type: Integer
-    seq_num:
+
+icustays:
+  table_name: icustays
+  columns:
+    subject_id:
+      type: Integer
+    hadm_id:
+      type: Integer
+    stay_id:
+      type: Integer
+      primary_key: true
+    first_careunit:
+      type: String
+    last_careunit:
+      type: String
+    intime:
+      type: String
+    outtime:
+      type: String
+    los:
+      type: Float
+
+labevents:
+  table_name: labevents
+  columns:
+    labevent_id:
+      type: Integer
+      primary_key: true
+    subject_id:
+      type: Integer
+    hadm_id:
+      type: Float
+    specimen_id:
+      type: Integer
+    itemid:
+      type: Integer
+    order_provider_id:
+      type: Float
+    charttime:
+      type: String
+    storetime:
+      type: String
+    value:
+      type: String
+    valuenum:
+      type: Float
+    valueuom:
+      type: String
+    ref_range_lower:
+      type: Float
+    ref_range_upper:
+      type: Float
+    flag:
+      type: String
+    priority:
+      type: String
+    comments:
+      type: String
+
+microbiologyevents:
+  table_name: microbiologyevents
+  columns:
+    microevent_id:
+      type: Integer
+      primary_key: true
+    subject_id:
+      type: Integer
+    hadm_id:
+      type: Float
+    micro_specimen_id:
+      type: Integer
+    order_provider_id:
+      type: Float
+    chartdate:
+      type: String
+    charttime:
+      type: String
+    spec_itemid:
+      type: Integer
+    spec_type_desc:
+      type: String
+    test_seq:
+      type: Integer
+    storedate:
+      type: String
+    storetime:
+      type: String
+    test_itemid:
+      type: Integer
+    test_name:
+      type: String
+    org_itemid:
+      type: Float
+    org_name:
+      type: String
+    isolate_num:
+      type: Float
+    quantity:
+      type: Float
+    ab_itemid:
+      type: Float
+    ab_name:
+      type: String
+    dilution_text:
+      type: String
+    dilution_comparison:
+      type: String
+    dilution_value:
+      type: Float
+    interpretation:
+      type: String
+    comments:
+      type: String
+
+patients:
+  table_name: patients
+  columns:
+    subject_id:
+      type: Integer
+      primary_key: true
+    gender:
+      type: String
+    anchor_age:
+      type: Integer
+    anchor_year:
+      type: Integer
+    anchor_year_group:
+      type: String
+    dod:
+      type: String
+
+procedureevents:
+  table_name: procedureevents
+  columns:
+    subject_id:
+      type: Integer
+    hadm_id:
+      type: Integer
+    stay_id:
+      type: Integer
+    caregiver_id:
+      type: Float
+    starttime:
+      type: String
+    endtime:
+      type: String
+    storetime:
+      type: String
+    itemid:
+      type: Integer
+    value:
+      type: Integer
+    valueuom:
+      type: String
+    location:
+      type: String
+    locationcategory:
+      type: String
+    orderid:
+      type: Integer
+      primary_key: true
+    linkorderid:
+      type: Integer
+    ordercategoryname:
+      type: String
+    ordercategorydescription:
+      type: String
+    patientweight:
+      type: Float
+    isopenbag:
+      type: Integer
+    continueinnextdept:
+      type: Integer
+    statusdescription:
+      type: String
+    ORIGINALAMOUNT:
+      type: Integer
+    ORIGINALRATE:
       type: Integer
 
 procedures_icd:
@@ -74,45 +274,44 @@ procedures_icd:
   columns:
     subject_id:
       type: Integer
+      primary_key: true
     hadm_id:
       type: Integer
     icd_code:
-      type: String
+      type: Float
     icd_version:
       type: Integer
 
-labevents:
-  table_name: labevents
+services:
+  table_name: services
   columns:
-    itemid:
-      type: Integer
     subject_id:
       type: Integer
     hadm_id:
       type: Integer
-    charttime:
-      type: DateTime
-    value:
+    transfertime:
       type: String
-    valuenum:
-      type: Float
-    valueuom:
+      primary_key: true
+    prev_service:
+      type: String
+    curr_service:
       type: String
 
-chartevents:
-  table_name: chartevents
+transfers:
+  table_name: transfers
   columns:
-    itemid:
-      type: Integer
     subject_id:
       type: Integer
     hadm_id:
-      type: Integer
-    charttime:
-      type: DateTime
-    value:
-      type: String
-    valuenum:
       type: Float
-    valueuom:
+    transfer_id:
+      type: Integer
+      primary_key: true
+    eventtype:
+      type: String
+    careunit:
+      type: String
+    intime:
+      type: String
+    outtime:
       type: String

--- a/omopetl/templates/demo/config/target_schema.yaml
+++ b/omopetl/templates/demo/config/target_schema.yaml
@@ -1,16 +1,11 @@
 person:
-  table_name: person
   columns:
     person_id:
       type: Integer
       primary_key: true
     gender_concept_id:
       type: Integer
-    birth_datetime:
-      type: DateTime
-
 visit_occurrence:
-  table_name: visit_occurrence
   columns:
     visit_occurrence_id:
       type: Integer
@@ -23,9 +18,7 @@ visit_occurrence:
       type: DateTime
     visit_end_datetime:
       type: DateTime
-
 visit_detail:
-  table_name: visit_detail
   columns:
     visit_detail_id:
       type: Integer
@@ -37,18 +30,14 @@ visit_detail:
       type: DateTime
     visit_detail_end_datetime:
       type: DateTime
-
 death:
-  table_name: death
   columns:
     person_id:
       type: Integer
       primary_key: true
     death_datetime:
       type: DateTime
-
 condition_occurrence:
-  table_name: condition_occurrence
   columns:
     condition_source_value:
       type: String
@@ -60,9 +49,7 @@ condition_occurrence:
       type: DateTime
     condition_concept_id:
       type: Integer
-
 procedure_occurrence:
-  table_name: procedure_occurrence
   columns:
     procedure_source_value:
       type: String
@@ -72,9 +59,7 @@ procedure_occurrence:
       type: Integer
     procedure_concept_id:
       type: Integer
-
 measurement:
-  table_name: measurement
   columns:
     measurement_source_value:
       type: String


### PR DESCRIPTION
In https://github.com/tompollard/omopetl/pull/7 we updated the demo data to use files derived from MIMIC-IV v2.2.

The configuration files were not updated, so running `omopetl run DEMO` currently fails with an error (as noted in https://github.com/tompollard/omopetl/pull/15).

This pull request:
1. Updates the `source_schema.yml` file in the demo project to match the files.
2. Adds a new `inferschema` command to the command line too, that will attempt to infer the schema from a set of files.
3. Updates the tests to run `omopetl run DEMO --dry`, which should prevent errors like this in the future. 

