### PR TITLE
Adds a `validate_relationships()` step to the transforms. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,19 +111,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     group_by: [subject_id, charttime]
 ```
 
-6. Row Filtering: Include or exclude rows based on conditions.
-
-    Example: Exclude diagnoses_icd rows with icd_version = 10.
-
-```
-- source_column: icd_version
-  target_column: condition_concept_id
-  transformation:
-    type: filter
-    condition: "icd_version == 9"
-```
-
-7. Concatenation: Concatenate multiple columns into a single column, often used for generating unique identifiers.
+6. Concatenation: Concatenate multiple columns into a single column, often used for generating unique identifiers.
 
     Example: Concatenating subject_id and stay_id to form visit_detail_id.
 
@@ -135,7 +123,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     separator: "-"
 ```
 
-8. Default Values: Assign a default value to a column when the source column is missing or null.
+7. Default Values: Assign a default value to a column when the source column is missing or null.
 
     Example: Assigning a default concept ID for missing admission_type.
 
@@ -146,7 +134,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     value: 44818518
 ```
 
-9. Multi-Table Merging: Combine data from multiple source tables into a single target table.
+8. Multi-Table Merging: Combine data from multiple source tables into a single target table.
 
     Example: Combining admissions and transfers into VISIT_OCCURRENCE.
 
@@ -158,7 +146,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     merge_key: hadm_id
 ```
 
-10. Conditional Transformations: Apply transformations based on conditions in the source data.
+9. Conditional Transformations: Apply transformations based on conditions in the source data.
 
     Example: Assigning different visit_concept_id values based on admission_type.
 
@@ -174,7 +162,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
         value: 9201
 ```
 
-11. Derived Columns: Calculate new columns from existing data (e.g., differences between dates).
+10. Derived Columns: Calculate new columns from existing data (e.g., differences between dates).
 
     Example: Calculating length_of_stay as the difference between dischtime and admittime.
 
@@ -186,7 +174,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     formula: "dischtime - admittime"
 ```
 
-12. Splitting Columns: Split a single source column into multiple target columns.
+11. Splitting Columns: Split a single source column into multiple target columns.
 
     Example: Splitting dob into year_of_birth, month_of_birth, and day_of_birth.
 
@@ -200,7 +188,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
     type: split_date
 ```
 
-13. Multi-Step Transformations: Apply a sequence of transformations to a single column.
+12. Multi-Step Transformations: Apply a sequence of transformations to a single column.
 
     Example: Normalize a date and then filter rows based on the normalized value.
 

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -21,7 +21,7 @@ class Transformer:
         Returns:
         - DataFrame: Transformed data with only the specified columns.
         """
-        transformed_data = pd.DataFrame()  # Start with an empty DataFrame
+        transformed_data = pd.DataFrame()
 
         for mapping in column_mappings:
             source_column = mapping.get("source_column")
@@ -54,7 +54,19 @@ class Transformer:
             if target_column and transformed_column is not None:
                 transformed_data[target_column] = transformed_column
 
+        # Validate relationships
+        breakpoint()
+        self._validate_relationships(transformed_data)
+
         return transformed_data
+
+    def _validate_relationships(self, transformed_data):
+        """
+        Validate source and target rows.
+        """
+        # Check alignment of rows against original data
+        if len(self.data) != len(transformed_data):
+            raise ValueError("Row count mismatch after transformations. Relationships may be broken.")
 
     # Transformation methods
     def transform_map(self, source_column, target_column, transformation):
@@ -71,26 +83,6 @@ class Transformer:
         """Normalize date values to a specific format."""
         date_format = transformation.get("format", "%Y-%m-%d")
         return pd.to_datetime(self.data[source_column], errors="coerce").dt.strftime(date_format)
-
-    def transform_filter(self, source_column, target_column, transformation):
-        """
-        Filter rows based on a condition.
-
-        Parameters:
-        - source_column: Not applicable for filtering.
-        - target_column: Not applicable for filtering.
-        - transformation: Transformation details including condition.
-
-        Returns:
-        - None: The filtering operation modifies self.data in place.
-        """
-        condition = transformation["condition"]
-
-        # Apply the condition to filter rows in the DataFrame
-        self.data = self.data.query(condition).copy()
-
-        # No return; filtering modifies self.data directly
-        return None
 
     def transform_aggregate(self, source_column, target_column, transformation):
         """Aggregate values based on a group_by condition."""

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -55,7 +55,6 @@ class Transformer:
                 transformed_data[target_column] = transformed_column
 
         # Validate relationships
-        breakpoint()
         self._validate_relationships(transformed_data)
 
         return transformed_data
@@ -117,8 +116,19 @@ class Transformer:
         return self.data[source_columns].astype(str).agg(separator.join, axis=1)
 
     def transform_default(self, source_column, target_column, transformation):
-        """Assign a default value."""
-        return transformation["value"]
+        """
+        Assign a default value.
+
+        Parameters:
+        - source_column: Ignored for default transformations.
+        - target_column: The name of the target column to populate.
+        - transformation: Dictionary containing the default value.
+
+        Returns:
+        - Series: A pandas Series filled with the default value, matching the length of the source data.
+        """
+        default_value = transformation["value"]
+        return pd.Series(default_value, index=self.data.index)
 
     def transform_conditional_map(self, source_column, target_column, transformation):
         """Apply conditional mappings."""

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -77,25 +77,6 @@ def test_normalize_date(transformer):
     assert transformed_data["birth_datetime"].tolist() == ["1980-01-01", "1990-05-20", "2000-07-15"]
 
 
-def test_filter(transformer):
-    column_mappings = [
-        {
-            "source_column": None,  # Not applicable for filtering
-            "target_column": None,  # Filtering modifies rows, not columns
-            "transformation": {
-                "type": "filter",
-                "condition": "value > 2",  # Only rows where value > 2 should remain
-            },
-        }
-    ]
-    transformer.apply_transformations(column_mappings)
-
-    # Assert that only rows matching the filter condition remain
-    filtered_data = transformer.data
-    assert len(filtered_data) == 2
-    assert filtered_data["value"].tolist() == [2.5, 3.5]
-
-
 def test_aggregate(transformer):
     column_mappings = [
         {


### PR DESCRIPTION
This pull request:

1. Adds a `validate_relationships` function to the transformation step, to help ensure that transforms do not break relationships between columns
2. Removes the `transform_filter` function, which fails the `validate_relationships` test (because it reduces the length of the array).
3. Fixes the `transform_default`, which was returning a single default value rather than an array.