### PR TITLE
Add ability to link between tables ("link on transform")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # OMOPETL
 
-Package for creating OMOP ETLs.
-
-## Usage
-
 The `omopetl` package has two core tools:
 
 1. `startproject`: Create an ETL project that contains configuration files for mapping between two data structures, and
 2. `run`: Run the ETL project on source data to create a set of data in the target format.
 
-### 1. Initializing a transformation project with `startproject`
+## 1. Initializing a transformation project with `startproject`
 
 When a user runs `omopetl startproject myproject`, the following folder structure is created:
 
@@ -27,7 +23,7 @@ myproject/
 
 After initialising the project, it is necessary to configure the transformation rules by updating the files in the `config` folder.
 
-### 2. Running a transformation with `run`
+## 2. Running a transformation with `run`
 
 Once your project is configured, you can run transform the data in your source folder (`./myproject/data/source/*`) with the following command:
 
@@ -37,7 +33,7 @@ omopetl run myproject --dry
 
 The `--dry` argument does a dry run only, meaning the code is run but the files are not saved. Remove the `--dry` argument to run the full transformation.
 
-## Demo
+## 3. Demo
 
 For an example project, you can start a new demo project with:
 
@@ -47,9 +43,19 @@ omopetl startdemo mydemo
 
 This mirrors the structure created with `startproject`. The only difference is that `config` folder is configured to transform the data in the `source` folder to OMOP.
 
-## Transformations
+## 4. Transformations
 
 At the core of the `omopetl` project are the transformations. These are a set of rules that allow you to map from the source format to the target format.
+
+**By design, transformations always return a column with the same length as the source data**. This helps to ensure row level integrity of the transformed data. If a transformation alters the length of an array, an error is raised.
+
+Where multiple source tables map to a target table, `omopetl` follows a "link during transformation" approach**. This involves:
+
+- Identifying the primary table with the primary rows for the transformation.
+- Specifying data to fetch from other tables.
+- Defining aggregation rules to handle multiple matches (e.g. first, average, sum, etc).
+
+## 5. Catalogue of transformations
 
 1. Direct Column Mapping: Map a column from the source table directly to a column in the target table without modification.
 
@@ -202,7 +208,7 @@ At the core of the `omopetl` project are the transformations. These are a set of
       condition: "visit_start_datetime >= '2020-01-01'"
 ```
 
-## Configuring your transformation
+## 6. Configuring your project
 
 After creating your new project with `omopetl startproject <PROJECTNAME>`, you will need to configure the transformation. We recommend the following approach:
 

--- a/omopetl/pipeline.py
+++ b/omopetl/pipeline.py
@@ -4,39 +4,6 @@ from omopetl.transform import Transformer
 from omopetl.utils import load_yaml
 
 
-def extract_and_combine_data(config, source_tables, project_path, source_schema):
-    """
-    Extract data from multiple source tables and combine them.
-
-    Parameters:
-    - config: The ETL configuration.
-    - source_tables: List of source tables to extract data from.
-    - project_path: The project folder path.
-    - source_schema: The source schema definition for validation.
-
-    Returns:
-    - DataFrame: Combined data from all source tables.
-    """
-    combined_data = pd.DataFrame()
-    source_dir = os.path.join(project_path, config['etl']['source']['directory'])
-
-    for source_table in source_tables:
-        file_path = os.path.join(source_dir, f"{source_table}.csv")
-        if not os.path.exists(file_path):
-            raise FileNotFoundError(f"Source file not found: {file_path}")
-
-        # extract data
-        data = pd.read_csv(file_path)
-
-        # validate schema
-        validate_schema(data, source_schema, source_table)
-
-        # combine data
-        combined_data = pd.concat([combined_data, data], ignore_index=True)
-
-    return combined_data
-
-
 def load_data(config, data, target_table, project_path):
     """
     Load data into the target, resolving paths relative to the project path.

--- a/omopetl/templates/demo/config/etl_config.yaml
+++ b/omopetl/templates/demo/config/etl_config.yaml
@@ -10,39 +10,4 @@ etl:
     schema_file: ./config/target_schema.yaml
 
   mappings:
-    - source_tables: 
-        - patients
-      target_table: person
-      column_mappings: person_mapping
-
-    - source_tables:
-        - admissions
-        - transfers
-      target_table: visit_occurrence
-      column_mappings: visit_occurrence_mapping
-
-    - source_tables: 
-        - icustays
-      target_table: visit_detail
-      column_mappings: visit_detail_mapping
-
-    - source_tables: 
-        - patients
-      target_table: death
-      column_mappings: death_mapping
-
-    - source_tables:
-        - diagnoses_icd
-      target_table: condition_occurrence
-      column_mappings: condition_occurrence_mapping
-
-    - source_tables:
-        - procedures_icd
-      target_table: procedure_occurrence
-      column_mappings: procedure_occurrence_mapping
-
-    - source_tables:
-        - labevents
-        - chartevents
-      target_table: measurement
-      column_mappings: measurement_mapping
+    - person_mapping

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -1,93 +1,13 @@
 person_mapping:
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: gender
-    target_column: gender_concept_id
-    transformation:
-      type: map
-      values:
-        M: 8507
-        F: 8532
-
-visit_occurrence_mapping:
-  - source_column: hadm_id
-    target_column: visit_occurrence_id
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: admittime
-    target_column: visit_start_datetime
-  - source_column: dischtime
-    target_column: visit_end_datetime
-  - source_column: admission_type
-    target_column: visit_concept_id
-    transformation:
-      type: map
-      values:
-        EMERGENCY: 9203
-        URGENT: 9203
-        ELECTIVE: 9201
-
-visit_detail_mapping:
-  - source_column: stay_id
-    target_column: visit_detail_id
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: hadm_id
-    target_column: visit_occurrence_id
-  - source_column: intime
-    target_column: visit_detail_start_datetime
-  - source_column: outtime
-    target_column: visit_detail_end_datetime
-
-death_mapping:
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: dod
-    target_column: death_datetime
-
-condition_occurrence_mapping:
-  - source_column: icd_code
-    target_column: condition_source_value
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: hadm_id
-    target_column: visit_occurrence_id
-  - source_column: seq_num
-    target_column: condition_start_datetime
-  - source_column: icd_version
-    target_column: condition_concept_id
-    transformation:
-      type: lookup
-      vocabulary: icd_to_snomed
-
-procedure_occurrence_mapping:
-  - source_column: icd_code
-    target_column: procedure_source_value
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: hadm_id
-    target_column: visit_occurrence_id
-  - source_column: icd_version
-    target_column: procedure_concept_id
-    transformation:
-      type: lookup
-      vocabulary: icd_to_snomed
-
-measurement_mapping:
-  - source_column: itemid
-    target_column: measurement_source_value
-  - source_column: subject_id
-    target_column: person_id
-  - source_column: hadm_id
-    target_column: visit_occurrence_id
-  - source_column: charttime
-    target_column: measurement_datetime
-  - source_column: value
-    target_column: value_as_number
-  - source_column: valuenum
-    target_column: value_as_concept_id
-    transformation:
-      type: map
-      values:
-        0: 0
-        1: 1
+  source_table: patients
+  target_table: person
+  transformations:
+    - source_column: subject_id
+      target_column: person_id
+    - source_column: gender
+      target_column: gender_concept_id
+      transformation:
+        type: map
+        values:
+          M: 8507
+          F: 8532

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -11,3 +11,10 @@ person_mapping:
         values:
           M: 8507
           F: 8532
+    - target_column: ethnicity
+      linked_table: admissions
+      link_column: subject_id
+      source_column: race
+      transformation:
+        type: aggregate
+        method: most_frequent

--- a/omopetl/templates/demo/config/target_schema.yaml
+++ b/omopetl/templates/demo/config/target_schema.yaml
@@ -5,6 +5,8 @@ person:
       primary_key: true
     gender_concept_id:
       type: Integer
+    ethnicity:
+      type: String
 visit_occurrence:
   columns:
     visit_occurrence_id:

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -11,30 +11,72 @@ class Transformer:
         """
         self.data = data
 
-    def apply_transformations(self, column_mappings):
+    def apply_transformations(self, transformations, project_path):
         """
         Apply transformations based on column mappings.
 
         Parameters:
-        - column_mappings: List of mappings with transformation details.
+        - transformations: List of mappings with transformation details.
+        - project_path: Path to the project directory.
 
         Returns:
         - DataFrame: Transformed data with only the specified columns.
         """
         transformed_data = pd.DataFrame()
 
-        for mapping in column_mappings:
+        for mapping in transformations:
             source_column = mapping.get("source_column")
-            source_columns = mapping.get("source_columns")
             target_column = mapping["target_column"]
             transformation = mapping.get("transformation")
 
-            # Handle direct column mapping
+            # Handle linked table transformation
+            if "linked_table" in mapping:
+                linked_table_name = mapping["linked_table"]
+                link_column = mapping["link_column"]
+
+                # Load the linked table
+                linked_table_path = os.path.join(project_path, "data", "source", f"{linked_table_name}.csv")
+                if not os.path.exists(linked_table_path):
+                    raise FileNotFoundError(f"Linked table not found: {linked_table_path}")
+
+                linked_table = pd.read_csv(linked_table_path)
+
+                # Handle aggregation if specified
+                if transformation and transformation["type"] == "aggregate":
+                    method = transformation.get("method", "first")
+                    if method == "most_frequent":
+                        aggregated_data = (
+                            linked_table.groupby(link_column)[source_column]
+                            .agg(lambda x: x.value_counts().idxmax())
+                            .reset_index()
+                        )
+                    elif method == "first":
+                        aggregated_data = linked_table.groupby(link_column).first().reset_index()
+                    elif method == "last":
+                        aggregated_data = linked_table.groupby(link_column).last().reset_index()
+                    else:
+                        raise ValueError(f"Unknown aggregation method: {method}")
+
+                    # Merge aggregated data with the base table
+                    self.data = self.data.merge(
+                        aggregated_data,
+                        how="left",
+                        left_on=source_column,
+                        right_on=link_column,
+                        suffixes=("", f"_{linked_table_name}")
+                    )
+
+                # Add the aggregated column to the target column
+                transformed_data[target_column] = self.data[f"{source_column}_{linked_table_name}"]
+                continue
+
+            # Handle direct column mapping without transformation
             if not transformation:
                 if source_column and target_column:
                     transformed_data[target_column] = self.data[source_column]
                 continue
 
+            # Handle transformations
             transform_type = transformation["type"]
             method = getattr(self, f"transform_{transform_type}", None)
 
@@ -42,15 +84,13 @@ class Transformer:
                 raise ValueError(f"Unsupported transformation type: {transform_type}")
 
             if transform_type == "concatenate":
-                # Pass source_columns for concatenate transformation
+                source_columns = mapping.get("source_columns")
                 if not source_columns:
                     raise KeyError("source_columns is required for concatenate transformation.")
                 transformed_column = method(source_columns, target_column, transformation)
             else:
-                # Pass source_column for other transformations
                 transformed_column = method(source_column, target_column, transformation)
 
-            # Add the transformed column to the transformed DataFrame
             if target_column and transformed_column is not None:
                 transformed_data[target_column] = transformed_column
 
@@ -71,7 +111,7 @@ class Transformer:
     def transform_map(self, source_column, target_column, transformation):
         """Map values in the source column to new values."""
         value_map = transformation["values"]
-        return self.data[source_column].map(value_map).astype("Int64")
+        return self.data[source_column].map(value_map)
 
     def transform_lookup(self, source_column, target_column, transformation):
         """Perform a lookup transformation using a vocabulary."""

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 
 
@@ -61,13 +63,13 @@ class Transformer:
                     self.data = self.data.merge(
                         aggregated_data,
                         how="left",
-                        left_on=source_column,
+                        left_on=link_column,
                         right_on=link_column,
-                        suffixes=("", f"_{linked_table_name}")
+                        suffixes=("", "")
                     )
 
                 # Add the aggregated column to the target column
-                transformed_data[target_column] = self.data[f"{source_column}_{linked_table_name}"]
+                transformed_data[target_column] = self.data[source_column]
                 continue
 
             # Handle direct column mapping without transformation


### PR DESCRIPTION
This pull request adds the ability to link between tables, following a "link on transform" approach. With this approach, we link supplementary data during the transformation step.

e.g. we extract ethnicity from the admissions table by passing the subject_id and extracting matched ethnicities.

The validation rules need updating to ensure data integrity (see https://github.com/tompollard/omopetl/issues/16). 