### PR TITLE
move linking to transform.

### DIFF
--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -76,11 +76,12 @@ person_mapping:
     - target_column: ethnicity_source_concept_id
       transformation:
         type: default
-        value: 
+        value:
     - target_column: ethnicity
-      linked_table: admissions
-      link_column: subject_id
-      source_column: race
       transformation:
-        type: aggregate
-        method: most_frequent
+        type: link
+        linked_table: admissions
+        link_column: subject_id
+        source_column: race
+        aggregation:
+          method: most_frequent


### PR DESCRIPTION
This pull request updates the syntax for linking tables. We now handle linking as a transformation step, e.g.:

```
    - target_column: ethnicity
      transformation:
        type: link
        linked_table: admissions
        link_column: subject_id
        source_column: race
        aggregation:
          method: most_frequent
```

This approach is more consistent with the idea of chaining transformations.