### PR TITLE
Support chained transformations

### DIFF
--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -5,16 +5,19 @@ person_mapping:
     - target_column: person_id
       transformation:
         type: generate_id
-    - source_column: gender
-      target_column: gender_concept_id
+    - target_column: gender_concept_id
       transformation:
         type: map
+        source_column: gender
         values:
           M: 8507
           F: 8532
     - target_column: year_of_birth
       transformation:
         type: derive
+        source_columns:
+          - anchor_year
+          - anchor_age
         formula: "anchor_year - anchor_age"
     - target_column: month_of_birth
       transformation:
@@ -52,8 +55,7 @@ person_mapping:
       transformation:
         type: default
         value: 
-    - source_column: gender
-      target_column: gender_source_value
+    - target_column: gender_source_value
       transformation:
         type: default
         value: 

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -29,17 +29,35 @@ class Transformer:
 
         for column in columns:
             target_column = column["target_column"]
-            transformation = column.get("transformation")
-            transform_type = transformation["type"]
+            transformations = column.get("transformations", [column.get("transformation")])
 
-            # Load the transformation method
-            method = getattr(self, f"transform_{transform_type}", None)
-            if method is None:
-                raise ValueError(f"Unsupported transformation type: {transform_type}")
+            if not transformations or not isinstance(transformations, list):
+                raise ValueError(f"Invalid or missing transformations for column '{target_column}'")
 
-            # Call the transformation method
-            source_column = column.get("source_column")
-            transformed_data[target_column] = method(source_column, target_column, transformation)
+            # Fetch source columns from the transformation section
+            source_columns = transformations[0].get("source_columns") or [transformations[0].get("source_column")]
+
+            # Handle the initial data for the transformation
+            # For a link transformation, initial data is not from self.data
+            if transformations[0]["type"] == "link":
+                current_data = None
+            else:
+                current_data = self.data[source_columns] if source_columns[0] else None
+
+            # Chain the transformations
+            for transformation in transformations:
+                transform_type = transformation["type"]
+
+                # Load the transformation method
+                method = getattr(self, f"transform_{transform_type}", None)
+                if method is None:
+                    raise ValueError(f"Unsupported transformation type: {transform_type}")
+
+                # Apply the transformation
+                current_data = method(current_data, target_column, transformation)
+
+            # Store the final transformed column
+            transformed_data[target_column] = current_data
 
         # Validate relationships
         self._validate_relationships(transformed_data)
@@ -55,17 +73,19 @@ class Transformer:
             raise ValueError("Row count mismatch after transformations. Relationships may be broken.")
 
     # Transformation methods
-    def transform_map(self, source_column, target_column, transformation):
+    def transform_map(self, current_data, target_column, transformation):
         """Map values in the source column to new values."""
+        source_column = transformation.get("source_column")
         value_map = transformation["values"]
-        return self.data[source_column].map(value_map)
+        return current_data[source_column].map(value_map)
 
     # Transformation methods
-    def transform_copy(self, source_column, target_column, transformation):
+    def transform_copy(self, current_data, target_column, transformation):
         """Copy values from the source column."""
-        return self.data[source_column]
+        source_column = transformation["source_column"]
+        return current_data[source_column]
 
-    def transform_link(self, source_column, target_column, transformation):
+    def transform_link(self, current_data, target_column, transformation):
         """
         Handle linked table transformation with optional aggregation.
 
@@ -85,7 +105,6 @@ class Transformer:
         if not link_column:
             raise KeyError("'link_column' is required for a 'link' transformation.")
 
-        # Override the source_column using the version specified in the transform.
         source_column = transformation["source_column"]
 
         # Load the linked table
@@ -126,32 +145,19 @@ class Transformer:
         # Return the linked column data
         return self.data[source_column]
 
-    def transform_lookup(self, source_column, target_column, transformation):
+    def transform_lookup(self, current_data, target_column, transformation):
         """Perform a lookup transformation using a vocabulary."""
+        source_column = transformation.get("source_column")
         vocabulary = transformation["vocabulary"]
-        return self.data[source_column].apply(lambda x: self.perform_lookup(vocabulary, x)).astype("Int64")
+        return current_data[source_column].apply(lambda x: self.perform_lookup(vocabulary, x)).astype("Int64")
 
-    def transform_normalize_date(self, source_column, target_column, transformation):
+    def transform_normalize_date(self, current_data, target_column, transformation):
         """Normalize date values to a specific format."""
+        source_column = transformation.get("source_column")
         date_format = transformation.get("format", "%Y-%m-%d")
-        return pd.to_datetime(self.data[source_column], errors="coerce").dt.strftime(date_format)
+        return pd.to_datetime(current_data[source_column], errors="coerce").dt.strftime(date_format)
 
-    def transform_aggregate(self, source_column, target_column, transformation):
-        """Aggregate values based on a group_by condition."""
-        group_by = transformation["group_by"]
-        method = transformation["method"]
-
-        # Perform aggregation
-        aggregated = self.data.groupby(group_by).agg({source_column: method}).reset_index()
-        aggregated.rename(columns={source_column: target_column}, inplace=True)
-
-        # Merge the aggregated results back into the main DataFrame
-        self.data = pd.merge(self.data, aggregated, on=group_by, how="left")
-
-        # Return the target column to allow integration in the pipeline
-        return self.data[target_column]
-
-    def transform_concatenate(self, source_columns, target_column, transformation):
+    def transform_concatenate(self, current_data, target_column, transformation):
         """
         Concatenate multiple columns into a single column.
 
@@ -163,12 +169,13 @@ class Transformer:
         Returns:
         - Series: Concatenated column as a pandas Series.
         """
+        source_columns = transformation.get("source_columns")
         if not source_columns:
             raise KeyError("source_columns is required for concatenate transformation.")
         separator = transformation.get("separator", "-")
-        return self.data[source_columns].astype(str).agg(separator.join, axis=1)
+        return current_data[source_columns].astype(str).agg(separator.join, axis=1)
 
-    def transform_default(self, source_column, target_column, transformation):
+    def transform_default(self, current_data, target_column, transformation):
         """
         Assign a default value.
 
@@ -183,30 +190,38 @@ class Transformer:
         default_value = transformation["value"]
         return pd.Series(default_value, index=self.data.index)
 
-    def transform_conditional_map(self, source_column, target_column, transformation):
-        """Apply conditional mappings."""
+    def transform_conditional_map(self, current_data, target_column, transformation):
+        """
+        Apply conditional mappings to the source column, with optional default value.
+
+        Parameters:
+        - current_data: Current data being processed.
+        - target_column: The target column name (not used here).
+        - transformation: Dictionary containing transformation details, including conditions.
+
+        Returns:
+        - Series: The column with conditionally mapped values.
+        """
         conditions = transformation["conditions"]
-        result_column = pd.Series(index=self.data.index, dtype="Int64")
+        # Optional default value
+        default_value = transformation.get("default", None)
+        result_column = pd.Series(default_value, index=self.data.index, dtype="Int64")
+
         for condition in conditions:
             condition_str = condition["condition"]
             value = condition["value"]
-            result_column[self.data.eval(condition_str)] = value
+            # Apply the condition and assign the value
+            mask = current_data.eval(condition_str)
+            result_column[mask] = value
+
         return result_column
 
-    def transform_derive(self, source_column, target_column, transformation):
+    def transform_derive(self, current_data, target_column, transformation):
         """Calculate derived values using a formula."""
         formula = transformation["formula"]
-        return self.data.eval(formula)
+        return current_data.eval(formula)
 
-    def transform_split_date(self, source_column, target_column, transformation):
-        """Split date values into year, month, and day."""
-        date_parts = ["year", "month", "day"]
-        for part in date_parts:
-            if f"{part}_of_birth" in transformation["target_columns"]:
-                self.data[f"{part}_of_birth"] = pd.to_datetime(self.data[source_column]).dt.__getattribute__(part)
-        return self.data
-
-    def transform_generate_id(self, source_column, target_column, transformation):
+    def transform_generate_id(self, current_data, target_column, transformation):
         """Generate a universal unique identifier for each row in the source column."""
         return [str(uuid.uuid4()) for _ in range(len(self.data))]
 

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -78,7 +78,12 @@ class Transformer:
         - Series: The transformed column data.
         """
         linked_table_name = transformation["linked_table"]
+        if not linked_table_name:
+            raise KeyError("'linked_table' is required for a 'link' transformation.")
+
         link_column = transformation["link_column"]
+        if not link_column:
+            raise KeyError("'link_column' is required for a 'link' transformation.")
 
         # Override the source_column using the version specified in the transform.
         source_column = transformation["source_column"]

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -32,10 +32,10 @@ def transformer(sample_data):
 def test_direct_mapping(transformer):
     columns = [
         {
-            "source_column": "gender",
             "target_column": "gender_target",
             "transformation": {
                 "type": "copy",
+                "source_column": "gender",
             },
         }
     ]
@@ -47,10 +47,10 @@ def test_direct_mapping(transformer):
 def test_value_mapping(transformer):
     columns = [
         {
-            "source_column": "gender",
             "target_column": "gender_concept_id",
             "transformation": {
                 "type": "map",
+                "source_column": "gender",
                 "values": {"M": 8507, "F": 8532},
             },
         }
@@ -64,10 +64,10 @@ def test_value_mapping(transformer):
 def test_lookup(transformer):
     columns = [
         {
-            "source_column": "icd_code",
             "target_column": "condition_concept_id",
             "transformation": {
                 "type": "lookup",
+                "source_column": "icd_code",
                 "vocabulary": "icd_to_snomed",
             },
         }
@@ -79,10 +79,10 @@ def test_lookup(transformer):
 def test_normalize_date(transformer):
     column_mappings = [
         {
-            "source_column": "dob",
             "target_column": "birth_datetime",
             "transformation": {
                 "type": "normalize_date",
+                "source_column": "dob",
                 "format": "%Y-%m-%d",
             },
         }
@@ -97,29 +97,13 @@ def test_normalize_date(transformer):
     assert transformed_data["birth_datetime"].tolist() == ["1980-01-01", "1990-05-20", "2000-07-15"]
 
 
-def test_aggregate(transformer):
-    columns = [
-        {
-            "source_column": "value",
-            "target_column": "aggregated_value",
-            "transformation": {
-                "type": "aggregate",
-                "group_by": ["charttime"],
-                "method": "sum",
-            },
-        }
-    ]
-    transformed_data = transformer.apply_transformations(columns)
-    assert "aggregated_value" in transformed_data.columns
-
-
 def test_concatenate(transformer):
     columns = [
         {
-            "source_column": ["subject_id", "gender"],
             "target_column": "subject_gender_id",
             "transformation": {
                 "type": "concatenate",
+                "source_columns": ["subject_id", "gender"],
                 "separator": "-",
             },
         }
@@ -148,10 +132,10 @@ def test_default(transformer):
 def test_conditional_map(transformer):
     columns = [
         {
-            "source_column": "gender",
             "target_column": "conditional_gender_id",
             "transformation": {
                 "type": "conditional_map",
+                "source_column": "gender",
                 "conditions": [
                     {"condition": "gender == 'M'", "value": 8507},
                     {"condition": "gender == 'F'", "value": 8532},
@@ -169,6 +153,7 @@ def test_derive(transformer):
             "target_column": "derived_column",
             "transformation": {
                 "type": "derive",
+                "source_column": "value",
                 "formula": "value * 2",
             },
         }


### PR DESCRIPTION
This update adds support for chained transformations. It's still buggy, so will need cleaning up later. One significant change is that `source_column` (or `source_columns`) is now part of the `transformation` section:

```
person_mapping:
  source_table: patients
  target_table: person
  columns:
    - target_column: person_id
      transformation:
        type: generate_id
    - target_column: gender_concept_id
      transformation:
        type: map
        source_column: gender
        values:
          M: 8507
          F: 8532
    - target_column: year_of_birth
      transformation:
        type: derive
        source_columns:
          - anchor_year
          - anchor_age
        formula: "anchor_year - anchor_age"
```