### PR TITLE
Add order_by for linked transformations.

### DIFF
--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -199,6 +199,9 @@ class Transformer:
 
         source_column = transformation["source_column"]
 
+        # Optional ordering for aggregation
+        order_by = transformation.get("order_by")
+
         # Attempt to load the linked table from source directory
         linked_table_path = os.path.join(self.project_path, "data", "source", f"{linked_target_table_name}.csv")
         if not os.path.exists(linked_table_path):
@@ -214,6 +217,11 @@ class Transformer:
         aggregation = transformation.get("aggregation")
         if aggregation:
             method = aggregation.get("method", "first")
+
+            # Apply ordering if specified
+            if order_by:
+                linked_table = linked_table.sort_values(order_by)
+
             if method == "most_frequent":
                 aggregated_data = (
                     linked_table.groupby(link_column)[source_column]


### PR DESCRIPTION
This pull request introduces support for `order_by` variables on the link transformation. For example:

```
columns:
  - target_column: visit_start_time
    transformation:
      type: link
      linked_table: visits
      link_column: person_id
      source_column: visit_time
      aggregation:
        method: first
      order_by:
        - visit_time
```

Previously, the behaviour of `first`, `last`, etc was unclear.