### PR TITLE
Add example staging table to demo project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,4 @@ jobs:
         omopetl startdemo DEMO
 
         # Run the ETL in dry mode
-        omopetl run DEMO --dry
+        omopetl run DEMO

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ visit_occurrence:
 
 This file is primarily used for validating your transform (for example, making sure that relationships are maintained between variables).
 
+**If you are creating staging tables as part of your ETL, it is important that they are also described in the target schema!**
+
 3. Add details of your source tables and column mapping rules to `etl_config.yaml`:
 
 ```
@@ -312,6 +314,8 @@ etl:
     person_mapping
     visit_occurrence_mapping
 ```
+
+**Don't forget to include your list of mappings in this file, including any mappings that create staging tables.**
 
 4. Add your transformations to `mappings.yaml`:
 

--- a/omopetl/templates/demo/config/etl_config.yaml
+++ b/omopetl/templates/demo/config/etl_config.yaml
@@ -10,4 +10,5 @@ etl:
     schema_file: ./config/target_schema.yaml
 
   mappings:
+    - staging_person_lookup
     - person_mapping

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -1,17 +1,35 @@
+staging_person_lookup:
+  source_table: patients
+  target_table: staging_person_lookup
+  columns:
+    - target_column: person_id
+      transformation:
+        type: generate_id
+    - target_column: subject_id
+      transformation:
+        type: copy
+        source_column: subject_id
+
 person_mapping:
   source_table: patients
   target_table: person
   columns:
     - target_column: person_id
       transformation:
-        type: generate_id
+        type: link
+        linked_table: staging_person_lookup
+        link_column: subject_id
+        source_column: person_id
     - target_column: gender_concept_id
       transformation:
-        type: map
+        type: conditional_map
         source_column: gender
-        values:
-          M: 8507
-          F: 8532
+        conditions:
+          - condition: "gender == 'F'"
+            value: 8532  # FEMALE
+          - condition: "gender == 'M'"
+            value: 8507  # MALE
+        default: 0
     - target_column: year_of_birth
       transformation:
         type: derive
@@ -26,11 +44,11 @@ person_mapping:
     - target_column: day_of_birth
       transformation:
         type: default
-        value: 
+        value: null
     - target_column: birth_datetime
       transformation:
         type: default
-        value: 
+        value: null
     - target_column: race_concept_id
       transformation:
         type: default
@@ -42,23 +60,23 @@ person_mapping:
     - target_column: location_id
       transformation:
         type: default
-        value: 
+        value: null
     - target_column: provider_id
       transformation:
         type: default
-        value: 
+        value: null
     - target_column: care_site_id
       transformation:
         type: default
-        value: 
+        value: null
     - target_column: person_source_value
       transformation:
-        type: default
-        value: 
+        type: copy
+        source_column: subject_id
     - target_column: gender_source_value
       transformation:
-        type: default
-        value: 
+        type: copy
+        source_column: gender
     - target_column: gender_source_concept_id
       transformation:
         type: default

--- a/omopetl/templates/demo/config/target_schema.yaml
+++ b/omopetl/templates/demo/config/target_schema.yaml
@@ -1,3 +1,11 @@
+staging_person_lookup:
+  columns:
+    subject_id:
+      type: Integer
+      primary_key: true
+    person_id:
+      type: String
+
 person:
   columns:
     person_id:


### PR DESCRIPTION
This pull request adds an example staging table to the demo project. 

```
staging_person_lookup:
  source_table: patients
  target_table: staging_person_lookup
  columns:
    - target_column: person_id
      transformation:
        type: generate_id
    - target_column: subject_id
      transformation:
        type: copy
        source_column: subject_id

person_mapping:
  source_table: patients
  target_table: person
  columns:
    - target_column: person_id
      transformation:
        type: link
        linked_table: staging_person_lookup
        link_column: subject_id
        source_column: person_id
    - target_column: gender_concept_id
      transformation:
        type: conditional_map
        source_column: gender
        conditions:
          - condition: "gender == 'F'"
            value: 8532  # FEMALE
          - condition: "gender == 'M'"
            value: 8507  # MALE
        default: 0
```