### PR TITLE
Support generate_id methods.Ref #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,29 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     - Orders by `admittime`
     - Selects the first recorded race by subject.
 
-13. Multi-Step Transformations: Apply a sequence of transformations to a single column.
+13. Generating Unique Identifiers: Generates a unique identifier for each row in the dataset.
+
+    Example: Example: Generate a UUID for `person_id`
+
+```
+- target_column: person_id
+  transformation:
+    type: generate_id
+    method: uuid
+- target_column: visit_id
+  transformation:
+    type: generate_id
+    method: incremental
+- target_column: hashed_subject_id
+  transformation:
+    type: generate_id
+    method: hash
+    source_column: subject_id
+```
+
+    Methods include: `uuid`, `incremental`, `hash`.
+
+14. Multi-Step Transformations: Apply a sequence of transformations to a single column.
 
     Example: Normalize a date and then filter rows based on the normalized value.
 

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -5,6 +5,7 @@ staging_person_lookup:
     - target_column: person_id
       transformation:
         type: generate_id
+        method: uuid
     - target_column: subject_id
       transformation:
         type: copy


### PR DESCRIPTION
Adds support for multiple `generate_id` methods, e.g.:

```
    - target_column: person_id
      transformation:
        type: generate_id
        method: incremental
```

Generates:

```
person_id,subject_id
1,10014729
2,10003400
3,10002428
4,10032725
5,10027445
...
```

and:

```
    - target_column: person_id
      transformation:
        type: generate_id
        method: uuid
```

generates:

```
person_id,subject_id
96c679c0-0bae-4d55-b508-ed4ad79349fc,10014729
8bc25942-bebd-4c6f-8525-d777e9706365,10003400
9b2f034e-aa61-4058-9af3-ae910a9afb25,10002428
89359722-7f93-4304-b812-b0d1e1c13a50,10032725
bee53956-5dec-47ea-ac1a-3da2473547bb,10027445
```
