### PR TITLE
rename target_column to add_column

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Mapping subject_id in patients to person_id in PERSON.
 
 ```
-- target_column: person_id
+- add_column: person_id
   transformation:
     type: copy
     source_column: subject_id
@@ -74,7 +74,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Mapping gender values `M` and `F` in patients to OMOP concept IDs `8507` (male) and `8532` (female).
 
 ```
-- target_column: gender_concept_id
+- add_column: gender_concept_id
   transformation:
     type: map
     source_column: gender
@@ -98,7 +98,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Mapping ICD codes to SNOMED concept IDs.
 
 ```
-- target_column: condition_concept_id
+- add_column: condition_concept_id
   transformation:
     type: lookup
     source_column: icd_code
@@ -113,7 +113,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Extracting the date in `YYYY-MM-DD` format from admittime.
 
 ```
-- target_column: visit_start_datetime
+- add_column: visit_start_datetime
   transformation:
     type: normalize_date
     source_column: admittime
@@ -125,7 +125,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example:  Retrieving the earliest `visit_start_time` for a patient using `subject_id`
 
 ```
-- target_column: visit_start_time
+- add_column: visit_start_time
   transformation:
     type: link
     linked_table: visits
@@ -142,7 +142,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Concatenating `subject_id` and `stay_id` to form visit_detail_id.
 
 ```
-- target_column: visit_detail_id
+- add_column: visit_detail_id
   transformation:
     type: concatenate
     source_columns: [subject_id, stay_id]
@@ -154,7 +154,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Assigning a default concept ID to `visit_concept_id` when missing.
 
 ```
-- target_column: visit_concept_id
+- add_column: visit_concept_id
   transformation:
     type: default
     value: 44818518
@@ -165,7 +165,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Using the `person` table to link `patient_id`s in a subsequent mapping.
 
 ```
-- target_column: patient_id
+- add_column: patient_id
   transformation:
     type: link
     linked_table: person
@@ -180,7 +180,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Assigning different visit_concept_id values based on admission_type.
 
 ```
-- target_column: visit_concept_id
+- add_column: visit_concept_id
   transformation:
     type: conditional_map
     source_column: admission_type
@@ -196,7 +196,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Calculating `length_of_stay` as the difference between dischtime and admittime.
 
 ```
-- target_column: length_of_stay
+- add_column: length_of_stay
   transformation:
     type: derive
     source_columns: [admittime, dischtime]
@@ -212,11 +212,11 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     source_table: admissions
     target_table: tmp_subject_race
     columns:
-      - target_column: subject_id
+      - add_column: subject_id
         transformation:
           type: copy
           source_column: subject_id
-      - target_column: race
+      - add_column: race
         transformation:
           type: aggregate
           source_columns:
@@ -238,15 +238,15 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Example: Generate a UUID for `person_id`
 
 ```
-- target_column: person_id
+- add_column: person_id
   transformation:
     type: generate_id
     method: uuid
-- target_column: visit_id
+- add_column: visit_id
   transformation:
     type: generate_id
     method: incremental
-- target_column: hashed_subject_id
+- add_column: hashed_subject_id
   transformation:
     type: generate_id
     method: hash
@@ -258,7 +258,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     Example: Normalize a date and then filter rows based on the normalized value.
 
 ```
-- target_column: visit_start_datetime
+- add_column: visit_start_datetime
   transformations:
     - type: normalize_date
       source_column: admittime
@@ -369,11 +369,11 @@ etl:
 
 ```
 person_mapping:
-  - target_column: person_id
+  - add_column: person_id
     transformation:
       type: copy
       source_column: subject_id
-  - target_column: gender_concept_id
+  - add_column: gender_concept_id
     transformation:
       type: map
       source_column: gender
@@ -382,19 +382,19 @@ person_mapping:
         F: 8532
 
 visit_occurrence_mapping:
-  - target_column: visit_occurrence_id
+  - add_column: visit_occurrence_id
     transformation:
       type: copy
       source_column: hadm_id
-  - target_column: person_id
+  - add_column: person_id
     transformation:
       type: copy
       source_column: subject_id
-  - target_column: visit_start_datetime
+  - add_column: visit_start_datetime
     transformation:
       type: copy
       source_column: admittime
-  - target_column: visit_end_datetime
+  - add_column: visit_end_datetime
     transformation:
       type: copy
       source_column: dischtime

--- a/omopetl/templates/demo/config/mappings.yaml
+++ b/omopetl/templates/demo/config/mappings.yaml
@@ -2,11 +2,11 @@ staging_person_lookup:
   source_table: patients
   target_table: staging_person_lookup
   columns:
-    - target_column: person_id
+    - add_column: person_id
       transformation:
         type: generate_id
         method: uuid
-    - target_column: subject_id
+    - add_column: subject_id
       transformation:
         type: copy
         source_column: subject_id
@@ -15,11 +15,11 @@ tmp_subject_race:
   source_table: admissions
   target_table: tmp_subject_race
   columns:
-    - target_column: subject_id
+    - add_column: subject_id
       transformation:
         type: copy
         source_column: subject_id
-    - target_column: race
+    - add_column: race
       transformation:
         type: aggregate
         source_columns:
@@ -35,13 +35,13 @@ person_mapping:
   source_table: patients
   target_table: person
   columns:
-    - target_column: person_id
+    - add_column: person_id
       transformation:
         type: link
         linked_table: staging_person_lookup
         link_column: subject_id
         source_column: person_id
-    - target_column: gender_concept_id
+    - add_column: gender_concept_id
       transformation:
         type: conditional_map
         source_column: gender
@@ -51,74 +51,74 @@ person_mapping:
           - condition: "gender == 'M'"
             value: 8507  # MALE
         default: 0
-    - target_column: year_of_birth
+    - add_column: year_of_birth
       transformation:
         type: derive
         source_columns:
           - anchor_year
           - anchor_age
         formula: "anchor_year - anchor_age"
-    - target_column: month_of_birth
+    - add_column: month_of_birth
       transformation:
         type: default
         value: 
-    - target_column: day_of_birth
+    - add_column: day_of_birth
       transformation:
         type: default
         value: null
-    - target_column: birth_datetime
+    - add_column: birth_datetime
       transformation:
         type: default
         value: null
-    - target_column: race_concept_id
+    - add_column: race_concept_id
       transformation:
         type: default
         value: 
-    - target_column: ethnicity_concept_id
+    - add_column: ethnicity_concept_id
       transformation:
         type: default
         value: 
-    - target_column: location_id
+    - add_column: location_id
       transformation:
         type: default
         value: null
-    - target_column: provider_id
+    - add_column: provider_id
       transformation:
         type: default
         value: null
-    - target_column: care_site_id
+    - add_column: care_site_id
       transformation:
         type: default
         value: null
-    - target_column: person_source_value
+    - add_column: person_source_value
       transformation:
         type: copy
         source_column: subject_id
-    - target_column: gender_source_value
+    - add_column: gender_source_value
       transformation:
         type: copy
         source_column: gender
-    - target_column: gender_source_concept_id
+    - add_column: gender_source_concept_id
       transformation:
         type: default
         value: 0
-    - target_column: race_source_value
+    - add_column: race_source_value
       transformation:
         type: default
         value: 
-    - target_column: race_source_concept_id
+    - add_column: race_source_concept_id
       transformation:
         type: default
         value: 
-    - target_column: ethnicity_source_value
+    - add_column: ethnicity_source_value
       transformation:
         type: default
         value: 
-    - target_column: ethnicity_source_concept_id
+    - add_column: ethnicity_source_concept_id
       transformation:
         type: default
         value:
-    - target_column: ethnicity
+    - add_column: ethnicity
       transformation:
         type: link
         linked_table: admissions

--- a/omopetl/templates/project/config/mappings.yaml
+++ b/omopetl/templates/project/config/mappings.yaml
@@ -1,12 +1,12 @@
 person_mapping:
   - source_column: subject_id
-    target_column: person_id
+    add_column: person_id
 
   - source_column: dob
-    target_column: birth_datetime
+    add_column: birth_datetime
 
   - source_column: gender
-    target_column: gender_concept_id
+    add_column: gender_concept_id
     transformation:
       type: map
       values:

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -95,7 +95,7 @@ class Transformer:
         transformed_data = pd.DataFrame()
 
         for column in columns:
-            target_column = column["target_column"]
+            target_column = column["add_column"]
             transformations = column.get("transformations", [column.get("transformation")])
 
             if not transformations or not isinstance(transformations, list):

--- a/tests/test_transform_aggregate.py
+++ b/tests/test_transform_aggregate.py
@@ -37,7 +37,7 @@ def test_transform_aggregate(mock_transformer_race, sample_admissions):
     based on admittime per subject_id.
     """
     transformation = {
-        "target_column": "race",
+        "add_column": "race",
         "source_columns": ["subject_id", "admittime", "race"],
         "group_by": ["subject_id"],
         "order_by": "admittime",

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -96,7 +96,7 @@ def transformer(sample_data, project_path, source_schema, target_schema):
 def test_direct_mapping(transformer):
     columns = [
         {
-            "target_column": "gender_target",
+            "add_column": "gender_target",
             "transformation": {
                 "type": "copy",
                 "source_column": "gender",
@@ -111,7 +111,7 @@ def test_direct_mapping(transformer):
 def test_value_mapping(transformer):
     columns = [
         {
-            "target_column": "gender_concept_id",
+            "add_column": "gender_concept_id",
             "transformation": {
                 "type": "map",
                 "source_column": "gender",
@@ -128,7 +128,7 @@ def test_value_mapping(transformer):
 def test_normalize_date(transformer):
     column_mappings = [
         {
-            "target_column": "birth_datetime",
+            "add_column": "birth_datetime",
             "transformation": {
                 "type": "normalize_date",
                 "source_column": "dob",
@@ -150,7 +150,7 @@ def test_normalize_date(transformer):
 def test_concatenate(transformer):
     columns = [
         {
-            "target_column": "subject_gender_id",
+            "add_column": "subject_gender_id",
             "transformation": {
                 "type": "concatenate",
                 "source_columns": ["subject_id", "gender"],
@@ -167,7 +167,7 @@ def test_concatenate(transformer):
 def test_default(transformer):
     columns = [
         {
-            "target_column": "default_value_column",
+            "add_column": "default_value_column",
             "transformation": {
                 "type": "default",
                 "value": 42,
@@ -182,7 +182,7 @@ def test_default(transformer):
 def test_conditional_map(transformer):
     columns = [
         {
-            "target_column": "conditional_gender_id",
+            "add_column": "conditional_gender_id",
             "transformation": {
                 "type": "conditional_map",
                 "source_column": "gender",
@@ -200,7 +200,7 @@ def test_conditional_map(transformer):
 def test_derive(transformer):
     columns = [
         {
-            "target_column": "derived_column",
+            "add_column": "derived_column",
             "transformation": {
                 "type": "derive",
                 "source_column": "value",
@@ -215,7 +215,7 @@ def test_derive(transformer):
 def test_generate_id(transformer):
     columns = [
         {
-            "target_column": "person_id",
+            "add_column": "person_id",
             "transformation": {
                 "type": "generate_id"
             },
@@ -288,7 +288,7 @@ def test_transform_generate_id_missing_source_column(mock_transformer):
 def test_lookup(mock_transformer):
     columns = [
         {
-            "target_column": "condition_concept_id",
+            "add_column": "condition_concept_id",
             "transformation": {
                 "type": "lookup",
                 "source_column": "icd_code",
@@ -314,7 +314,7 @@ def test_lookup(mock_transformer):
 def test_output_type_validation(transformer):
     columns = [
         {
-            "target_column": "derived_column",
+            "add_column": "derived_column",
             "transformation": {
                 "type": "derive",
                 "source_column": "value",
@@ -346,7 +346,7 @@ def test_transform_link_without_order(transformer, project_path):
     # Define the transformation
     columns = [
         {
-            "target_column": "visit_start_time",
+            "add_column": "visit_start_time",
             "transformation": {
                 "type": "link",
                 "linked_table": "visits",


### PR DESCRIPTION
Small change to replace "target_column" with "add_column" in the yaml mappings. e.g. instead of:

```
staging_person_lookup:
  source_table: patients
  target_table: staging_person_lookup
  columns:
    - target_column: person_id
      transformation:
        type: generate_id
        method: uuid
    - target_column: subject_id
      transformation:
        type: copy
        source_column: subject_id
```

...we now do:

```
staging_person_lookup:
  source_table: patients
  target_table: staging_person_lookup
  columns:
    - add_column: person_id
      transformation:
        type: generate_id
        method: uuid
    - add_column: subject_id
      transformation:
        type: copy
        source_column: subject_id
```