### PR TITLE
Reorder columns based on target schema. Fixes #59.

### DIFF
--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -133,6 +133,10 @@ class Transformer:
             # Store the final transformed column
             transformed_data[target_column] = current_data
 
+        # Reorder columns based on target schema
+        expected_order = list(self.target_schema.get(self.table_name, {}).get("columns", {}).keys())
+        transformed_data = transformed_data.reindex(columns=expected_order)
+
         # Validate relationships
         self._validate_relationships(transformed_data)
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import pytest
+from omopetl.transform import Transformer
+
+
+@pytest.fixture
+def mock_transformer():
+    """
+    Fixture to create a Transformer instance with a mock target schema.
+    """
+
+    source_data = pd.DataFrame({
+        "subject_id": [1, 2, 3],
+        "race": ["White", "Black", "Asian"],
+        "admittime": ["2020-01-01", "2020-02-01", "2020-03-01"]
+    })
+
+    target_schema = {
+        "tmp_subject_race": {
+            "columns": {
+                "subject_id": {"type": "integer"},
+                "admittime": {"type": "string"},
+                "race": {"type": "string"}
+            }
+        }
+    }
+
+    return Transformer(source_data, "mock_project_path", {}, target_schema, "tmp_subject_race")
+
+
+def test_transform_reorder_columns(mock_transformer):
+    """Test if transformed data is reordered according to the target schema."""
+
+    transformations = [
+        {
+            "add_column": "subject_id",
+            "transformation": {"type": "copy", "source_column": "subject_id"}
+        },
+        {
+            "add_column": "race",
+            "transformation": {"type": "copy", "source_column": "race"}
+        },
+        {
+            "add_column": "admittime",
+            "transformation": {"type": "copy", "source_column": "admittime"}
+        }
+    ]
+
+    transformed_data = mock_transformer.apply_transformations(transformations)
+    expected_order = ["subject_id", "admittime", "race"]
+
+    assert transformed_data.columns.to_list() == expected_order, \
+        f"Expected column order {expected_order}, but got {list(transformed_data.columns)}"

--- a/tests/test_transformer.py
+++ b/tests/test_transformer.py
@@ -358,9 +358,14 @@ def test_transform_link_without_order(transformer, project_path):
     ]
 
     transformed_data = transformer.apply_transformations(columns)
+
+    # Select only the relevant columns for comparison
+    transformed_data = transformed_data[["visit_start_time"]]
+
     expected = pd.DataFrame({"visit_start_time": [date(2023, 1, 2),
                                                   date(2023, 1, 1),
                                                   date(2023, 1, 3)]})
+
     pd.testing.assert_frame_equal(transformed_data, expected)
 
 


### PR DESCRIPTION
Adds a step to the transformation process to reorder the columns based on the target schema. Fixes #59.