### PR TITLE
Change "transformations" to "transformation" for multistep transformations

### DIFF
--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -82,19 +82,19 @@ class Transformer:
         self.lookup_cache[lookup_name] = lookup_table
         return lookup_table
 
-    def apply_transformations(self, columns, strict=True):
+    def apply_transformations(self, sequence, strict=True):
         """
         Apply transformations based on column mappings.
 
         Parameters:
-        - columns: List of mappings with transformation details.
+        - sequence: List of mappings with transformation details.
 
         Returns:
         - DataFrame: Transformed data with only the specified columns.
         """
         transformed_data = pd.DataFrame()
 
-        for column in columns:
+        for column in sequence:
             target_column = column["add_column"]
             transformations = column.get("transformations", [column.get("transformation")])
 


### PR DESCRIPTION
@briangow pointed out that it was confusing to use `transformations` for multistep transformations and `transformation` for single transformations.

This pull request removes the use of `transformations`. We now always use `transformation`, regardless of the number of steps. 

e.g.

```
- add_column: visit_start_datetime
  transformations:
    - type: normalize_date
      source_column: admittime
      format: "%Y-%m-%d"
    - type: filter
      source_column: admittime
      condition: "visit_start_datetime >= '2020-01-01'"
```

is now:

```
- add_column: visit_start_datetime
  transformation:
    - type: normalize_date
      source_column: admittime
      format: "%Y-%m-%d"
    - type: filter
      source_column: admittime
      condition: "visit_start_datetime >= '2020-01-01'"
```
