### PR TITLE
Add optional delimiter for link transform tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     format: "%Y-%m-%d"
 ```
 
-6. Aggregation: Combines multiple rows or columns into summary values (e.g., `first`, `last`, `sum`) with optional ordering.
+6. Aggregation: Combines multiple rows or columns into summary values (e.g., `first`, `last`, `sum`) with optional ordering. For linked tables which aren't comma delimited, you can pass any delimiter recognized as a separator by `pandas.read_csv`.
 
     Example:  Retrieving the earliest `visit_start_time` for a patient using `subject_id`
 
@@ -131,6 +131,7 @@ Where multiple source tables map to a target table, **`omopetl` follows a "link 
     linked_table: visits
     link_column: subject_id
     source_column: visit_start_time
+    delimiter: "\t"
     aggregation:
       method: first
     order_by:

--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -231,7 +231,10 @@ class Transformer:
             msg = f"Linked table '{linked_target_table_name}' not found in 'source', 'lookups', or 'target' directories."
             raise FileNotFoundError(msg)
 
-        linked_table = pd.read_csv(linked_table_path)
+        if "delimiter" in transformation:
+            linked_table = pd.read_csv(linked_table_path, sep=transformation["delimiter"])
+        else:
+            linked_table = pd.read_csv(linked_table_path)
 
         # Handle aggregation if specified
         aggregation = transformation.get("aggregation")


### PR DESCRIPTION
This PR checks for a delimiter variable in the link transformation dictionary. If it exits, it passes the value entered for the delimiter as the `sep` for `pd.read_csv`.

