### PR TITLE
Allow linking between different column names

### DIFF
--- a/omopetl/transform.py
+++ b/omopetl/transform.py
@@ -211,6 +211,11 @@ class Transformer:
         if not link_column:
             raise KeyError("'link_column' is required for a 'link' transformation.")
 
+        if 'link_alias' in transformation:
+            link_alias = transformation["link_alias"]
+        else:
+            link_alias = link_column
+
         source_column = transformation["source_column"]
 
         # Optional ordering for aggregation
@@ -264,7 +269,7 @@ class Transformer:
         self.data = self.data.merge(
             aggregated_data,
             how="left",
-            left_on=link_column,
+            left_on=link_alias,
             right_on=link_column,
             suffixes=("", "")
         )


### PR DESCRIPTION
As discussed in #57 we want to be able to do a link between columns of different names (e.g. `subject_id` and `person_id`).  This PR allows for a `link_alias` to be passed. This `link_alias` should be the name of the column being linked to. It is used under the `pandas.merge` in `left_on`. 

This has not been thoroughly tested. 

I can add documentation once the approach is agreed upon.